### PR TITLE
修复无法播放m3u8文件

### DIFF
--- a/app/src/main/java/com/heyanle/easybangumi4/exo/MediaSourceFactory.kt
+++ b/app/src/main/java/com/heyanle/easybangumi4/exo/MediaSourceFactory.kt
@@ -4,6 +4,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.CacheDataSink
@@ -12,6 +13,7 @@ import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import com.heyanle.easybangumi4.APP
 import com.heyanle.easybangumi4.source_api.entity.PlayerInfo
 
 /**
@@ -29,9 +31,9 @@ class MediaSourceFactory(
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     fun get(playerInfo: PlayerInfo): MediaSource {
 
-        val dataSourceFactory: DataSource.Factory = DefaultHttpDataSource.Factory()
+        val httpDataSourceFactory = DefaultHttpDataSource.Factory()
             .setDefaultRequestProperties(playerInfo.header ?: emptyMap())
-
+        val dataSourceFactory = DefaultDataSource.Factory(APP, httpDataSourceFactory)
         val streamDataSinkFactory = CacheDataSink.Factory().setCache(normalCache)
         val normalCacheDataSourceFactory = CacheDataSource.Factory()
             .setCache(normalCache)


### PR DESCRIPTION
使用DefaultHttpDataSource.Factory时只能播放http链接, 无法播放m3u8文件, 改为使用DefaultDataSource.Factory支持多种协议的文件播放
![19d90d3d27d35307990eb79a9d72b133](https://github.com/easybangumiorg/EasyBangumi/assets/51293207/cbf05fda-e57b-4ae3-885e-51df5fe2d516)
![981550ef60db972ec5db8a3dadea0187](https://github.com/easybangumiorg/EasyBangumi/assets/51293207/52892cd3-e863-4649-88b9-2e8e0ebcaa23)
