### PR TITLE
feat: 封面 URL 支持 @Referer= / @User-Agent= 请求头后缀解析

### DIFF
--- a/app/src/main/java/com/heyanle/easybangumi4/ui/common/OkImage.kt
+++ b/app/src/main/java/com/heyanle/easybangumi4/ui/common/OkImage.kt
@@ -25,11 +25,41 @@ import coil.compose.AsyncImage
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.ImageRequest
+import okhttp3.Headers
 
 /**
  * Created by HeYanLe on 2023/1/10 16:42.
  * https://github.com/heyanLE
  */
+/**
+ * 解析封面 URL 中的请求头后缀约定：
+ * `https://img.example.com/pic.webp@Referer=https://movie.douban.com/@User-Agent=Mozilla/5.0 ...`
+ * 返回 (干净的图片 URL, 解析出的请求头)。
+ * 兼容任意 @Key=Value 顺序与多个标记。
+ */
+fun parseCoverImage(image: Any?): Pair<Any?, Map<String, String>> {
+    if (image !is String) return image to emptyMap()
+    val url = image
+    val markers = listOf("@Referer=", "@User-Agent=")
+    val first = markers.mapNotNull { url.indexOf(it).takeIf { i -> i >= 0 } }.minOrNull()
+        ?: return url to emptyMap()
+    val clean = url.substring(0, first)
+    val headers = mutableMapOf<String, String>()
+    var pos = first
+    while (pos < url.length) {
+        val marker = markers.firstOrNull { url.startsWith(it, pos) } ?: break
+        val key = when (marker) {
+            "@Referer=" -> "Referer"
+            else -> "User-Agent"
+        }
+        pos += marker.length
+        val next = markers.mapNotNull { url.indexOf(it, pos).takeIf { i -> i >= 0 } }.minOrNull() ?: url.length
+        headers[key] = url.substring(pos, next)
+        pos = next
+    }
+    return clean to headers
+}
+
 
 @Composable
 fun OkImage(
@@ -45,6 +75,7 @@ fun OkImage(
     placeholderRes: Int? = null,
     tint: Color? = null,
     alpha: Float = 1f,
+    headers: Map<String, String>? = null,
 ) {
     var need = true
     if (image == null || image == "" || (image is Int && image <= 0)) {
@@ -98,10 +129,21 @@ fun OkImage(
             }
 
             else -> {
+                val (cleanImage, urlHeaders) = parseCoverImage(image)
+                val mergedHeaders = urlHeaders + (headers ?: emptyMap())
                 AsyncImage(
                     model = ImageRequest
                         .Builder(LocalContext.current)
-                        .data(image)
+                        .data(cleanImage)
+                        .apply {
+                            if (mergedHeaders.isNotEmpty()) {
+                                headers(
+                                    Headers.Builder().apply {
+                                        mergedHeaders.forEach { (k, v) -> add(k, v) }
+                                    }.build()
+                                )
+                            }
+                        }
                         .apply {
                             if (placeholderRes == null) {
                                 placeholderColor?.let {


### PR DESCRIPTION
## 背景

部分内容源的封面 URL 会附加请求头后缀约定，例如（LANERC 系源）：

    https://img.example.com/pic.webp@Referer=https://movie.douban.com/@User-Agent=Mozilla/5.0...

这是防盗链图床（如豆瓣 img9.doubanio.com）的绕过约定：请求图片时必须携带 Referer 头，否则 403。

目前 Coil 会把这个带后缀的字符串当作 URL 直接请求 → 404/403，导致列表封面加载失败、错位。

## 改动

- `OkImage` 新增 `parseCoverImage`：把 `@Referer=` / `@User-Agent=` 后缀拆分为（干净 URL, 请求头映射），兼容任意标记顺序与多个标记
- 加载前先解析，干净 URL 作为 Coil 数据源，解析出的头合并进 `ImageRequest.headers`
- `OkImage` 签名新增可选参数 `headers: Map<String, String>? = null`（调用方可额外补充头）
- 不带后缀的普通 URL 行为完全不变（解析为 no-op）

## 效果

导入带该约定的源后，防盗链封面可正常加载（需源脚本配合使用后缀约定；源脚本侧不在此 PR 范围）。

## 验证

- 真机（OPPO PGZ110，Android 15）验证：LANERC 源 doubanio 封面正常显示
- `compileDebugKotlin` 通过